### PR TITLE
feat: implement Matomo dashboard plugin

### DIFF
--- a/config/plugins.js
+++ b/config/plugins.js
@@ -4,4 +4,8 @@ module.exports = () => ({
     enabled: true,
     resolve: './src/plugins/custom-sidebar'
   },
+  'matomo-dashboard': {
+    enabled: true,
+    resolve: './src/plugins/matomo-dashboard'
+  },
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,6 @@
         "react-router-dom": "5.3.4",
         "styled-components": "5.3.3"
       },
-      "devDependencies": {},
       "engines": {
         "node": ">=18.0.0 <=20.x.x",
         "npm": ">=6.0.0"

--- a/src/plugins/matomo-dashboard/README.md
+++ b/src/plugins/matomo-dashboard/README.md
@@ -1,0 +1,43 @@
+# Strapi Plugin - Matomo Dashboard
+
+A plugin for Strapi that embeds a Matomo analytics dashboard into the admin panel.
+
+## Configuration
+
+To use this plugin, you need to configure it with your Matomo instance's details.
+Create or edit the file `./config/plugins.js` in your Strapi project and add the following configuration:
+
+```javascript
+module.exports = ({ env }) => ({
+  // ... other plugins
+  'matomo-dashboard': {
+    enabled: true,
+    config: {
+      matomoUrl: env('MATOMO_URL', 'https://your-matomo-instance.com'),
+      matomoSiteId: env('MATOMO_SITE_ID', '1'),
+      matomoAuthToken: env('MATOMO_AUTH_TOKEN', 'your-auth-token'),
+    },
+  },
+});
+```
+
+It is recommended to use environment variables to store your Matomo credentials. Add the following to your `.env` file:
+
+```
+MATOMO_URL=https://your-matomo-instance.com
+MATOMO_SITE_ID=1
+MATOMO_AUTH_TOKEN=your-auth-token
+```
+
+### Configuration Options
+
+- `matomoUrl` (string): The URL of your Matomo instance.
+- `matomoSiteId` (string | number): The ID of the site you want to track in Matomo.
+- `matomoAuthToken` (string): Your Matomo authentication token. You can find this in your Matomo dashboard under `Settings > Personal > Security`.
+
+## Permissions
+
+This plugin adds a new permission to your Strapi application:
+- `plugin::matomo-dashboard.read`: Allows a user to see the Matomo dashboard page.
+
+To enable the dashboard for a role, go to `Settings > Administration Panel > Roles`, select a role, and check the `read` permission for the `matomo-dashboard` plugin.

--- a/src/plugins/matomo-dashboard/admin/src/components/Dashboard/index.js
+++ b/src/plugins/matomo-dashboard/admin/src/components/Dashboard/index.js
@@ -1,0 +1,54 @@
+import React from 'react';
+import { Box } from '@strapi/design-system/Box';
+import VisitsSummary from '../VisitsSummary';
+import TopPages from '../TopPages';
+import TopReferrers from '../TopReferrers';
+import TopKeywords from '../TopKeywords';
+import VisitsGraph from '../VisitsGraph';
+import DeviceStats from '../DeviceStats';
+import { Grid, GridItem } from '@strapi/design-system/Grid';
+
+const Dashboard = ({ data }) => {
+  if (!data) {
+    return null;
+  }
+
+  const {
+    visitsSummary,
+    topPages,
+    topReferrers,
+    topKeywords,
+    liveVisitors,
+    osStats,
+    browserStats,
+    deviceTypes,
+    visitsGraphData,
+  } = data;
+
+  return (
+    <Box>
+      <VisitsSummary data={visitsSummary} />
+      <Box marginTop={4}>
+        <Grid gap={4}>
+          <GridItem col={12}>
+            <VisitsGraph data={visitsGraphData} />
+          </GridItem>
+          <GridItem col={12}>
+            <DeviceStats os={osStats} browsers={browserStats} types={deviceTypes} />
+          </GridItem>
+          <GridItem col={4}>
+            <TopPages data={topPages} />
+          </GridItem>
+          <GridItem col={4}>
+            <TopReferrers data={topReferrers} />
+          </GridItem>
+          <GridItem col={4}>
+            <TopKeywords data={topKeywords} />
+          </GridItem>
+        </Grid>
+      </Box>
+    </Box>
+  );
+};
+
+export default Dashboard;

--- a/src/plugins/matomo-dashboard/admin/src/components/DeviceStats/index.js
+++ b/src/plugins/matomo-dashboard/admin/src/components/DeviceStats/index.js
@@ -1,0 +1,59 @@
+import React from 'react';
+import { PieChart, Pie, Cell, Tooltip, ResponsiveContainer } from 'recharts';
+import { Box } from '@strapi/design-system/Box';
+import { Typography } from '@strapi/design-system/Typography';
+import { Grid, GridItem } from '@strapi/design-system/Grid';
+
+const COLORS = ['#0088FE', '#00C49F', '#FFBB28', '#FF8042', '#AF19FF', '#FF1919'];
+
+const Chart = ({ title, data }) => {
+  if (!data || data.length === 0) {
+    return <Typography>No data available for {title}.</Typography>;
+  }
+
+  const chartData = data.map(item => ({ name: item.label, value: item.nb_visits }));
+
+  return (
+    <Box>
+      <Typography variant="delta" as="h3">{title}</Typography>
+      <ResponsiveContainer width="100%" height={200}>
+        <PieChart>
+          <Pie
+            data={chartData}
+            cx="50%"
+            cy="50%"
+            labelLine={false}
+            outerRadius={80}
+            fill="#8884d8"
+            dataKey="value"
+          >
+            {chartData.map((entry, index) => (
+              <Cell key={`cell-${index}`} fill={COLORS[index % COLORS.length]} />
+            ))}
+          </Pie>
+          <Tooltip />
+        </PieChart>
+      </ResponsiveContainer>
+    </Box>
+  );
+};
+
+const DeviceStats = ({ os, browsers, types }) => {
+  return (
+    <Box background="neutral0" shadow="tableShadow" hasRadius padding={4} marginTop={4}>
+      <Grid gap={4}>
+        <GridItem col={4}>
+          <Chart title="Operating Systems" data={os} />
+        </GridItem>
+        <GridItem col={4}>
+          <Chart title="Browsers" data={browsers} />
+        </GridItem>
+        <GridItem col={4}>
+          <Chart title="Device Types" data={types} />
+        </GridItem>
+      </Grid>
+    </Box>
+  );
+};
+
+export default DeviceStats;

--- a/src/plugins/matomo-dashboard/admin/src/components/Initializer/index.js
+++ b/src/plugins/matomo-dashboard/admin/src/components/Initializer/index.js
@@ -1,0 +1,20 @@
+import { useEffect, useRef } from 'react';
+import PropTypes from 'prop-types';
+import pluginId from '../../pluginId';
+
+const Initializer = ({ setPlugin }) => {
+  const ref = useRef();
+  ref.current = setPlugin;
+
+  useEffect(() => {
+    ref.current(pluginId, { isReady: true });
+  }, []);
+
+  return null;
+};
+
+Initializer.propTypes = {
+  setPlugin: PropTypes.func.isRequired,
+};
+
+export default Initializer;

--- a/src/plugins/matomo-dashboard/admin/src/components/PluginIcon/index.js
+++ b/src/plugins/matomo-dashboard/admin/src/components/PluginIcon/index.js
@@ -1,0 +1,6 @@
+import React from 'react';
+import ChartBubble from '@strapi/icons/ChartBubble';
+
+const PluginIcon = () => <ChartBubble />;
+
+export default PluginIcon;

--- a/src/plugins/matomo-dashboard/admin/src/components/TopKeywords/index.js
+++ b/src/plugins/matomo-dashboard/admin/src/components/TopKeywords/index.js
@@ -1,0 +1,36 @@
+import React from 'react';
+import { Table, Thead, Tbody, Tr, Td, Th } from '@strapi/design-system/Table';
+import { Box } from '@strapi/design-system/Box';
+import { Typography } from '@strapi/design-system/Typography';
+
+const TopKeywords = ({ data }) => {
+  if (!data || data.length === 0) {
+    return <Typography>No keyword data available.</Typography>;
+  }
+
+  return (
+    <Box background="neutral0" shadow="tableShadow" hasRadius padding={4}>
+      <Typography variant="delta" as="h3">Top Keywords (Last 30 days)</Typography>
+      <Box marginTop={2}>
+        <Table colCount={2} rowCount={data.length + 1}>
+          <Thead>
+            <Tr>
+              <Th><Typography>Keyword</Typography></Th>
+              <Th><Typography>Visits</Typography></Th>
+            </Tr>
+          </Thead>
+          <Tbody>
+            {data.map((keyword) => (
+              <Tr key={keyword.label}>
+                <Td><Typography textColor="neutral800">{keyword.label}</Typography></Td>
+                <Td><Typography textColor="neutral800">{keyword.nb_visits}</Typography></Td>
+              </Tr>
+            ))}
+          </Tbody>
+        </Table>
+      </Box>
+    </Box>
+  );
+};
+
+export default TopKeywords;

--- a/src/plugins/matomo-dashboard/admin/src/components/TopPages/index.js
+++ b/src/plugins/matomo-dashboard/admin/src/components/TopPages/index.js
@@ -1,0 +1,38 @@
+import React from 'react';
+import { Table, Thead, Tbody, Tr, Td, Th } from '@strapi/design-system/Table';
+import { Box } from '@strapi/design-system/Box';
+import { Typography } from '@strapi/design-system/Typography';
+
+const TopPages = ({ data }) => {
+  if (!data || data.length === 0) {
+    return <Typography>No page data available.</Typography>;
+  }
+
+  return (
+    <Box background="neutral0" shadow="tableShadow" hasRadius padding={4}>
+      <Typography variant="delta" as="h3">Top Pages (Last 30 days)</Typography>
+      <Box marginTop={2}>
+        <Table colCount={3} rowCount={data.length + 1}>
+          <Thead>
+            <Tr>
+              <Th><Typography>Page URL</Typography></Th>
+              <Th><Typography>Visits</Typography></Th>
+              <Th><Typography>Unique Visitors</Typography></Th>
+            </Tr>
+          </Thead>
+          <Tbody>
+            {data.map((page) => (
+              <Tr key={page.label}>
+                <Td><Typography textColor="neutral800">{page.label}</Typography></Td>
+                <Td><Typography textColor="neutral800">{page.nb_visits}</Typography></Td>
+                <Td><Typography textColor="neutral800">{page.nb_uniq_visitors}</Typography></Td>
+              </Tr>
+            ))}
+          </Tbody>
+        </Table>
+      </Box>
+    </Box>
+  );
+};
+
+export default TopPages;

--- a/src/plugins/matomo-dashboard/admin/src/components/TopReferrers/index.js
+++ b/src/plugins/matomo-dashboard/admin/src/components/TopReferrers/index.js
@@ -1,0 +1,36 @@
+import React from 'react';
+import { Table, Thead, Tbody, Tr, Td, Th } from '@strapi/design-system/Table';
+import { Box } from '@strapi/design-system/Box';
+import { Typography } from '@strapi/design-system/Typography';
+
+const TopReferrers = ({ data }) => {
+  if (!data || data.length === 0) {
+    return <Typography>No referrer data available.</Typography>;
+  }
+
+  return (
+    <Box background="neutral0" shadow="tableShadow" hasRadius padding={4}>
+      <Typography variant="delta" as="h3">Top Referrers (Last 30 days)</Typography>
+      <Box marginTop={2}>
+        <Table colCount={2} rowCount={data.length + 1}>
+          <Thead>
+            <Tr>
+              <Th><Typography>Referrer</Typography></Th>
+              <Th><Typography>Visits</Typography></Th>
+            </Tr>
+          </Thead>
+          <Tbody>
+            {data.map((referrer) => (
+              <Tr key={referrer.label}>
+                <Td><Typography textColor="neutral800">{referrer.label}</Typography></Td>
+                <Td><Typography textColor="neutral800">{referrer.nb_visits}</Typography></Td>
+              </Tr>
+            ))}
+          </Tbody>
+        </Table>
+      </Box>
+    </Box>
+  );
+};
+
+export default TopReferrers;

--- a/src/plugins/matomo-dashboard/admin/src/components/VisitsGraph/index.js
+++ b/src/plugins/matomo-dashboard/admin/src/components/VisitsGraph/index.js
@@ -1,0 +1,35 @@
+import React from 'react';
+import { LineChart, Line, XAxis, YAxis, CartesianGrid, Tooltip, Legend, ResponsiveContainer } from 'recharts';
+import { Box } from '@strapi/design-system/Box';
+import { Typography } from '@strapi/design-system/Typography';
+
+const VisitsGraph = ({ data }) => {
+  if (!data) {
+    return <Typography>No graph data available.</Typography>;
+  }
+
+  const chartData = Object.keys(data).map(date => ({
+    date,
+    visits: data[date].nb_visits,
+  }));
+
+  return (
+    <Box background="neutral0" shadow="tableShadow" hasRadius padding={4}>
+      <Typography variant="delta" as="h3">Visits Over Last 30 Days</Typography>
+      <Box marginTop={4} style={{ height: 300 }}>
+        <ResponsiveContainer width="100%" height="100%">
+          <LineChart data={chartData}>
+            <CartesianGrid strokeDasharray="3 3" />
+            <XAxis dataKey="date" />
+            <YAxis />
+            <Tooltip />
+            <Legend />
+            <Line type="monotone" dataKey="visits" stroke="#8884d8" activeDot={{ r: 8 }} />
+          </LineChart>
+        </ResponsiveContainer>
+      </Box>
+    </Box>
+  );
+};
+
+export default VisitsGraph;

--- a/src/plugins/matomo-dashboard/admin/src/components/VisitsSummary/index.js
+++ b/src/plugins/matomo-dashboard/admin/src/components/VisitsSummary/index.js
@@ -1,0 +1,41 @@
+import React from 'react';
+import { Grid, GridItem } from '@strapi/design-system/Grid';
+import { Box } from '@strapi/design-system/Box';
+import { Typography } from '@strapi/design-system/Typography';
+import { Flex } from '@strapi/design-system/Flex';
+
+const SummaryBox = ({ label, value }) => (
+  <Box padding={4} background="neutral0" shadow="tableShadow" hasRadius>
+    <Flex direction="column" gap={1}>
+      <Typography variant="beta">{value}</Typography>
+      <Typography textColor="neutral600">{label}</Typography>
+    </Flex>
+  </Box>
+);
+
+const VisitsSummary = ({ data }) => {
+  if (!data) {
+    return null;
+  }
+
+  return (
+    <Box marginBottom={4}>
+      <Typography variant="delta" as="h3">Today's Summary</Typography>
+      <Box marginTop={2}>
+        <Grid gap={4}>
+          <GridItem col={4}>
+            <SummaryBox label="Total Visits" value={data.nb_visits} />
+          </GridItem>
+          <GridItem col={4}>
+            <SummaryBox label="Unique Visitors" value={data.nb_uniq_visitors} />
+          </GridItem>
+          <GridItem col={4}>
+            <SummaryBox label="Page Views" value={data.nb_pageviews} />
+          </GridItem>
+        </Grid>
+      </Box>
+    </Box>
+  );
+};
+
+export default VisitsSummary;

--- a/src/plugins/matomo-dashboard/admin/src/index.js
+++ b/src/plugins/matomo-dashboard/admin/src/index.js
@@ -1,0 +1,60 @@
+import { prefixPluginTranslations } from '@strapi/helper-plugin';
+import pluginPkg from '../../package.json';
+import pluginId from './pluginId';
+import Initializer from './components/Initializer';
+import PluginIcon from './components/PluginIcon';
+
+const name = pluginPkg.strapi.name;
+
+export default {
+  register(app) {
+    app.addMenuLink({
+      to: `/plugins/${pluginId}`,
+      icon: PluginIcon,
+      intlLabel: {
+        id: `${pluginId}.plugin.name`,
+        defaultMessage: name,
+      },
+      Component: async () => {
+        const component = await import('./pages/App');
+
+        return component;
+      },
+      permissions: [
+        {
+          action: 'plugin::matomo-dashboard.read',
+          subject: null,
+        },
+      ],
+    });
+    app.registerPlugin({
+      id: pluginId,
+      initializer: Initializer,
+      isReady: false,
+      name,
+    });
+  },
+
+  bootstrap(app) {},
+  async registerTrads({ locales }) {
+    const importedTrads = await Promise.all(
+      locales.map((locale) => {
+        return import(`./translations/${locale}.json`)
+          .then(({ default: data }) => {
+            return {
+              data: prefixPluginTranslations(data, pluginId),
+              locale,
+            };
+          })
+          .catch(() => {
+            return {
+              data: {},
+              locale,
+            };
+          });
+      })
+    );
+
+    return Promise.resolve(importedTrads);
+  },
+};

--- a/src/plugins/matomo-dashboard/admin/src/pages/App/index.js
+++ b/src/plugins/matomo-dashboard/admin/src/pages/App/index.js
@@ -1,0 +1,18 @@
+import React from 'react';
+import { Switch, Route } from 'react-router-dom';
+import { NotFound } from '@strapi/helper-plugin';
+import pluginId from '../../pluginId';
+import HomePage from '../HomePage';
+
+const App = () => {
+  return (
+    <div>
+      <Switch>
+        <Route path={`/plugins/${pluginId}`} component={HomePage} exact />
+        <Route component={NotFound} />
+      </Switch>
+    </div>
+  );
+};
+
+export default App;

--- a/src/plugins/matomo-dashboard/admin/src/pages/HomePage/index.js
+++ b/src/plugins/matomo-dashboard/admin/src/pages/HomePage/index.js
@@ -1,0 +1,61 @@
+import React from 'react';
+import { useQuery } from 'react-query';
+import { useFetchClient, LoadingIndicatorPage } from '@strapi/helper-plugin';
+import { Layout, HeaderLayout, ContentLayout } from '@strapi/design-system/Layout';
+import { Main } from '@strapi/design-system/Main';
+import { Typography } from '@strapi/design-system/Typography';
+import { Alert } from '@strapi/design-system/Alert';
+import Dashboard from '../../components/Dashboard';
+import pluginId from '../../pluginId';
+
+const HomePage = () => {
+  const { get } = useFetchClient();
+
+  const { isLoading, error, data } = useQuery(
+    ['matomo-data'],
+    async () => {
+      const { data } = await get(`/matomo-dashboard/data`);
+      return data;
+    }
+  );
+
+  if (isLoading) {
+    return <LoadingIndicatorPage>Loading Matomo data...</LoadingIndicatorPage>;
+  }
+
+  if (error) {
+    return (
+      <Layout>
+        <Main>
+          <HeaderLayout title="Matomo Dashboard" subtitle="Failed to load dashboard" />
+          <ContentLayout>
+            <Alert
+              title="Error"
+              variant="danger"
+              onClose={() => {}}
+              closeLabel="Close"
+            >
+              {error.message}
+            </Alert>
+          </ContentLayout>
+        </Main>
+      </Layout>
+    );
+  }
+
+  return (
+    <Layout>
+      <Main>
+        <HeaderLayout
+          title="Matomo Dashboard"
+          subtitle="Real-time analytics from your Matomo instance"
+        />
+        <ContentLayout>
+          <Dashboard data={data} />
+        </ContentLayout>
+      </Main>
+    </Layout>
+  );
+};
+
+export default HomePage;

--- a/src/plugins/matomo-dashboard/admin/src/pluginId.js
+++ b/src/plugins/matomo-dashboard/admin/src/pluginId.js
@@ -1,0 +1,5 @@
+import pluginPkg from '../../package.json';
+
+const pluginId = pluginPkg.name.replace(/^@strapi\/plugin-/i, '');
+
+export default pluginId;

--- a/src/plugins/matomo-dashboard/package.json
+++ b/src/plugins/matomo-dashboard/package.json
@@ -1,0 +1,44 @@
+{
+  "name": "matomo-dashboard",
+  "version": "0.0.0",
+  "description": "A Matomo analytics dashboard for Strapi.",
+  "strapi": {
+    "name": "matomo-dashboard",
+    "description": "A Matomo analytics dashboard for Strapi.",
+    "kind": "plugin",
+    "displayName": "Matomo Dashboard"
+  },
+  "dependencies": {
+    "@strapi/design-system": "^1.6.3",
+    "@strapi/helper-plugin": "^4.6.0",
+    "@strapi/icons": "^1.6.3",
+    "prop-types": "^15.7.2",
+    "axios": "^1.7.7",
+    "recharts": "^2.12.7"
+  },
+  "devDependencies": {
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
+    "react-router-dom": "^5.3.4",
+    "styled-components": "^5.3.6"
+  },
+  "peerDependencies": {
+    "react": "^17.0.0 || ^18.0.0",
+    "react-dom": "^17.0.0 || ^18.0.0",
+    "react-router-dom": "^5.2.0",
+    "styled-components": "^5.2.1"
+  },
+  "author": {
+    "name": "A Strapi developer"
+  },
+  "maintainers": [
+    {
+      "name": "A Strapi developer"
+    }
+  ],
+  "engines": {
+    "node": ">=18.0.0 <=20.x.x",
+    "npm": ">=6.0.0"
+  },
+  "license": "MIT"
+}

--- a/src/plugins/matomo-dashboard/server/config/index.js
+++ b/src/plugins/matomo-dashboard/server/config/index.js
@@ -1,0 +1,10 @@
+'use strict';
+
+module.exports = {
+  default: ({ env }) => ({
+    matomoUrl: 'https://stats.starsandtoques.com',
+    matomoSiteId: '',
+    matomoAuthToken: '',
+  }),
+  validator() {},
+};

--- a/src/plugins/matomo-dashboard/server/controllers/index.js
+++ b/src/plugins/matomo-dashboard/server/controllers/index.js
@@ -1,0 +1,7 @@
+'use strict';
+
+const matomoController = require('./matomo-controller');
+
+module.exports = {
+  matomoController,
+};

--- a/src/plugins/matomo-dashboard/server/controllers/matomo-controller.js
+++ b/src/plugins/matomo-dashboard/server/controllers/matomo-controller.js
@@ -1,0 +1,19 @@
+'use strict';
+
+module.exports = ({ strapi }) => ({
+  async index(ctx) {
+    try {
+      const data = await strapi
+        .plugin('matomo-dashboard')
+        .service('matomoService')
+        .getDashboardData();
+
+      ctx.body = data;
+    } catch (error) {
+      if (error.message.includes('must be configured')) {
+        return ctx.badRequest(error.message);
+      }
+      ctx.throw(500, error.message);
+    }
+  },
+});

--- a/src/plugins/matomo-dashboard/server/index.js
+++ b/src/plugins/matomo-dashboard/server/index.js
@@ -1,0 +1,25 @@
+'use strict';
+
+const register = require('./register');
+const bootstrap = require('./bootstrap');
+const destroy = require('./destroy');
+const config = require('./config');
+const contentTypes = require('./content-types');
+const controllers = require('./controllers');
+const routes = require('./routes');
+const middlewares = require('./middlewares');
+const policies = require('./policies');
+const services = require('./services');
+
+module.exports = {
+  register,
+  bootstrap,
+  destroy,
+  config,
+  controllers,
+  routes,
+  services,
+  contentTypes,
+  policies,
+  middlewares,
+};

--- a/src/plugins/matomo-dashboard/server/routes/index.js
+++ b/src/plugins/matomo-dashboard/server/routes/index.js
@@ -1,0 +1,10 @@
+module.exports = [
+  {
+    method: 'GET',
+    path: '/data',
+    handler: 'matomoController.index',
+    config: {
+      policies: [],
+    },
+  },
+];

--- a/src/plugins/matomo-dashboard/server/services/index.js
+++ b/src/plugins/matomo-dashboard/server/services/index.js
@@ -1,0 +1,7 @@
+'use strict';
+
+const matomoService = require('./matomo-service');
+
+module.exports = {
+  matomoService,
+};

--- a/src/plugins/matomo-dashboard/server/services/matomo-service.js
+++ b/src/plugins/matomo-dashboard/server/services/matomo-service.js
@@ -1,0 +1,83 @@
+'use strict';
+
+const axios = require('axios');
+
+const getApiClient = (config) => {
+  if (!config.matomoUrl || !config.matomoSiteId || !config.matomoAuthToken) {
+    throw new Error('Matomo URL, Site ID and Auth Token must be configured in the plugin settings.');
+  }
+
+  const { matomoUrl, matomoSiteId, matomoAuthToken } = config;
+
+  const client = axios.create({
+    baseURL: matomoUrl,
+  });
+
+  const buildParams = (method) => {
+    return {
+      module: 'API',
+      method,
+      idSite: matomoSiteId,
+      period: 'day',
+      date: 'today',
+      format: 'json',
+      token_auth: matomoAuthToken,
+    };
+  };
+
+  return {
+    get: async (method, params = {}) => {
+      try {
+        const response = await client.get('/index.php', {
+          params: { ...buildParams(method), ...params },
+        });
+        return response.data;
+      } catch (error) {
+        strapi.log.error(`Error fetching Matomo data for method ${method}:`, error);
+        throw new Error(`Could not fetch data from Matomo for method ${method}.`);
+      }
+    },
+  };
+};
+
+
+module.exports = ({ strapi }) => ({
+  async getDashboardData() {
+    const config = strapi.config.get('plugin.matomo-dashboard');
+    const apiClient = getApiClient(config);
+
+    const [
+      visitsSummary,
+      visitsGraphData,
+      topPages,
+      topReferrers,
+      topKeywords,
+      liveVisitors,
+      osStats,
+      browserStats,
+      deviceTypes,
+    ] = await Promise.all([
+      apiClient.get('VisitsSummary.get'),
+      apiClient.get('VisitsSummary.get', { period: 'day', date: 'last30' }),
+      apiClient.get('Actions.getPageUrls', { period: 'month', date: 'today' }),
+      apiClient.get('Referrers.getReferrerType', { period: 'month', date: 'today' }),
+      apiClient.get('Referrers.getKeywords', { period: 'month', date: 'today' }),
+      apiClient.get('Live.getLastVisitsDetails', { period: 'day', date: 'today', minTimestamp: Math.floor(Date.now() / 1000) - 300 }), // last 5 minutes
+      apiClient.get('DevicesDetection.getOsFamilies'),
+      apiClient.get('DevicesDetection.getBrowsers'),
+      apiClient.get('DevicesDetection.getType'),
+    ]);
+
+    return {
+      visitsSummary,
+      visitsGraphData,
+      topPages,
+      topReferrers,
+      topKeywords,
+      liveVisitors,
+      osStats,
+      browserStats,
+      deviceTypes,
+    };
+  },
+});

--- a/src/plugins/matomo-dashboard/strapi-admin.js
+++ b/src/plugins/matomo-dashboard/strapi-admin.js
@@ -1,0 +1,3 @@
+'use strict';
+
+module.exports = require('./admin/src').default;

--- a/src/plugins/matomo-dashboard/strapi-server.js
+++ b/src/plugins/matomo-dashboard/strapi-server.js
@@ -1,0 +1,3 @@
+'use strict';
+
+module.exports = require('./server');


### PR DESCRIPTION
This commit introduces a new Strapi plugin to display a Matomo analytics dashboard within the admin panel.

The plugin includes:
- A new page in the admin panel to display the dashboard.
- Server-side logic to fetch data from the Matomo API.
- Client-side components built with React and Strapi's Design System.
- Charts for data visualization using Recharts.
- Configuration via environment variables and `plugins.js`.
- Role-based access control for the dashboard page.
- A comprehensive README with setup instructions.